### PR TITLE
Can now add 6 images on snapshot. No images container improvements.

### DIFF
--- a/components/ImageGrid.jsx
+++ b/components/ImageGrid.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import { StyleSheet, View, TouchableOpacity, Image } from 'react-native';
-import NoImages from '../assets/no-photo.png';
+import { StyleSheet, View, TouchableOpacity, Image, Text } from 'react-native';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 
 const ImageGrid = ({ images, onImagePress }) => {
+
     const imageCount = images.length;
 
     return (
         <View style={[
-            styles.container,
+            imageCount === 0 ? styles.containerNoImages : styles.container,
             imageCount === 2 && styles.containerTwo,
-            imageCount === 3 && styles.containerThree
+            imageCount === 3 && styles.containerThree,
+            (imageCount === 5 || imageCount === 6) && styles.containerFiveOrSix
         ]}>
             {imageCount === 0 ? (
                 <View style={styles.noPhotoWrapper}>
-                    <Image source={NoImages} style={styles.noPhotoImage} />
+                    <Ionicons name="camera" size={70} color="#CDA7AF" />
+                    <Text style={styles.noImagesText}>No Images. Tap + to add.</Text>
                 </View>
             ) : (
             images.map((image, index) => (
@@ -25,6 +28,8 @@ const ImageGrid = ({ images, onImagePress }) => {
                         imageCount === 2 && styles.imageWrapperTwo,
                         imageCount === 3 && (index < 2 ? styles.imageWrapperThreeSmall : styles.imageWrapperThreeLarge),
                         imageCount === 4 && styles.imageWrapperFour,
+                        imageCount === 5 && (index === 4 ? styles.imageWrapperFiveLarge : styles.imageWrapperFiveSmall),
+                        imageCount === 6 && styles.imageWrapperSix,
                     ]}
                     onPress={() => onImagePress(index)}
                 >
@@ -43,11 +48,21 @@ const styles = StyleSheet.create({
         width: 350,
         height: 350
     },
+    containerNoImages: {
+        width: 350,
+        height: 100        
+    },
+    noImagesText: {
+        color: '#3F4F5F',
+    },
     containerTwo: {
         flexDirection: 'column',
     },
     containerThree: {
         flexDirection: 'row',
+    },
+    containerFiveOrSix: {
+        flexDirection: 'column',
     },
     noPhotoWrapper: {
         width: '100%',
@@ -83,6 +98,18 @@ const styles = StyleSheet.create({
     imageWrapperFour: {
         width: '50%',
         height: '50%',
+    },
+    imageWrapperFiveSmall: {
+        width: '50%',
+        height: '33.33%',
+    },
+    imageWrapperFiveLarge: {
+        width: '100%',
+        height: '66.66%',
+    },
+    imageWrapperSix: {
+        width: '50%',
+        height: '33.33%',
     },
     image: {
         width: '100%',

--- a/pages/Spanshot.jsx
+++ b/pages/Spanshot.jsx
@@ -5,10 +5,13 @@ import someImage from '../assets/dummy-image.jpg';
 import ImageGrid from '../components/ImageGrid';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import useFileBrowser from '../hooks/useFileBrowser';
 
 const Snapshot = () => {
 
     const navigation = useNavigation();
+
+    const { filesInfo, browseFiles } = useFileBrowser();
 
     const [showImageModal, setShowImageModal] = useState(false);
 
@@ -73,9 +76,14 @@ const Snapshot = () => {
                 <View style={styles.imageSection}>
                     <View style={styles.imageSectionHeader}>
                         <Text style={styles.sectionHeader}>Images</Text>
-                        <TouchableOpacity>
-                            <Ionicons name="create-outline" size={30} color="#3F4F5F" />
-                        </TouchableOpacity>
+                        {dummyImages.length > 0 ?
+                            <TouchableOpacity>
+                                <Ionicons name="create-outline" size={30} color="#3F4F5F" />
+                            </TouchableOpacity> :
+                            <TouchableOpacity onPress={browseFiles}>
+                                <Ionicons name="add-outline" size={30} color="#3F4F5F" />
+                            </TouchableOpacity> 
+                        }
                     </View>
                     <View style={styles.imageSliderContainer}>
                         <ImageGrid images={dummyImages} onImagePress={() => setShowImageModal(true)} />


### PR DESCRIPTION
- Added styling to the container so up to 6 images can be added.
- Made the no images container smaller.
- Removed the no images image and added an icon with some text.
- The edit button is replaced by a plus button on the image container when there are no images.
- The plus button on the image container takes user to the file selection.